### PR TITLE
Make FAB align with background

### DIFF
--- a/lib/config/style_data.dart
+++ b/lib/config/style_data.dart
@@ -23,7 +23,7 @@ import 'package:flutter/material.dart';
 /// Will probably eventually be replaced by themes.
 
 class StyleData {
-  static const double screenPaddingValue = 35;
+  static const double screenPaddingValue = 32;
 
   static const EdgeInsets screenPadding =
       EdgeInsets.symmetric(horizontal: screenPaddingValue);


### PR DESCRIPTION
The outermost screen-margin was slightly reduced to make it align with the FloatingActionButton

Closes #10.